### PR TITLE
Add support for disabling specific dates in the date picker

### DIFF
--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -37,6 +37,13 @@ extension DateTimeExtension on DateTime {
     return dateCompareTo(start) >= 0 && dateCompareTo(end) <= 0;
   }
 
+  bool isBlockedDate(List<DateTime> blockedDates, DateTime currentDate) {
+    return blockedDates.any((date) =>
+        date.year == currentDate.year &&
+        date.month == currentDate.month &&
+        date.day == currentDate.day);
+  }
+
   int monthCompareTo(DateTime other) {
     if (year < other.year) {
       return -1;

--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -44,6 +44,7 @@ Future<DateTimeRange?> showWebDatePicker({
   int? firstDayOfWeekIndex,
   bool asDialog = false,
   bool enableDateRangeSelection = false,
+  List<DateTime>? blockedDates,
 }) {
   if (asDialog) {
     final renderBox = context.findRenderObject()! as RenderBox;
@@ -68,6 +69,7 @@ Future<DateTimeRange?> showWebDatePicker({
               cancelButtonColor: cancelButtonColor,
               backgroundColor: backgroundColor,
               enableDateRangeSelection: enableDateRangeSelection,
+              blockedDates: blockedDates ?? [],
             ),
           ),
         ),
@@ -89,6 +91,7 @@ Future<DateTimeRange?> showWebDatePicker({
         cancelButtonColor: cancelButtonColor,
         backgroundColor: backgroundColor,
         enableDateRangeSelection: enableDateRangeSelection,
+        blockedDates: blockedDates ?? [],
       ),
       asDropDown: true,
       useTargetWidth: width != null ? false : true,
@@ -103,6 +106,7 @@ class _WebDatePicker extends StatefulWidget {
     this.initialDate2,
     required this.firstDate,
     required this.lastDate,
+    required this.blockedDates,
     this.withoutActionButtons = false,
     this.weekendDaysColor,
     required this.firstDayOfWeekIndex,
@@ -113,6 +117,7 @@ class _WebDatePicker extends StatefulWidget {
     this.enableDateRangeSelection = false,
   });
 
+  final List<DateTime> blockedDates;
   final DateTime initialDate;
   final DateTime? initialDate2;
   final DateTime firstDate;
@@ -193,7 +198,9 @@ class _WebDatePickerState extends State<_WebDatePicker> {
     for (int i = 0; i < kNumberCellsOfMonth; i++) {
       final date = monthDateRange.start.add(Duration(days: i));
       if (_viewStartDate.month == date.month) {
-        final isEnabled = date.isInDateRange(widget.firstDate, widget.lastDate);
+        final isEnabled =
+            date.isInDateRange(widget.firstDate, widget.lastDate) &&
+                !date.isBlockedDate(widget.blockedDates, date);
         final isSelected =
             date.isInDateRange(_selectedStartDate, _selectedEndDate);
         final isSelectedLeft =


### PR DESCRIPTION
This update introduces the ability to disable specific dates in the date picker. A `List<DateTime>` can now be provided to block certain dates from selection. This enhancement improves flexibility by allowing better control over available date choices.