### PR TITLE
Update intl dependency version range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.19.0
+  intl: '>=0.19.0-0 <0.21.0'
   vph_common_widgets: ^0.0.3
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^5.0.0
 
 flutter:


### PR DESCRIPTION
Changed the intl package version constraint to '>=0.19.0-0 <0.21.0' to allow for a wider range of compatible versions.