### PR TITLE
Add parameters to hide OK and cancel buttons

### DIFF
--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -31,6 +31,8 @@ Future<DateTimeRange?> showWebDatePicker({
   Size? initSize,
   bool showTodayButton = true,
   bool showResetButton = true,
+  bool showOkButton = true,
+  bool showCancelButton = true,
   bool autoCloseOnDateSelect = false,
   void Function()? onReset,
 }) {
@@ -62,6 +64,8 @@ Future<DateTimeRange?> showWebDatePicker({
               showTodayButton: showTodayButton,
               showResetButton: showResetButton,
               autoCloseOnDateSelect: autoCloseOnDateSelect,
+              showOkButton: showOkButton,
+              showCancelButton: showCancelButton,
               onReset: onReset,
             ),
           ),
@@ -89,6 +93,8 @@ Future<DateTimeRange?> showWebDatePicker({
         showTodayButton: showTodayButton,
         showResetButton: showResetButton,
         autoCloseOnDateSelect: autoCloseOnDateSelect,
+        showOkButton: showOkButton,
+        showCancelButton: showCancelButton,
         onReset: onReset,
       ),
       asDropDown: true,
@@ -116,6 +122,8 @@ class _WebDatePicker extends StatefulWidget {
     this.initSize,
     this.showTodayButton = true,
     this.showResetButton = true,
+    this.showOkButton = true,
+    this.showCancelButton = true,
     this.autoCloseOnDateSelect = false,
     this.onReset,
   });
@@ -136,6 +144,8 @@ class _WebDatePicker extends StatefulWidget {
   final Size? initSize;
   final bool showTodayButton;
   final bool showResetButton;
+  final bool showOkButton;
+  final bool showCancelButton;
   final bool autoCloseOnDateSelect;
   final void Function()? onReset;
 
@@ -692,16 +702,17 @@ class _WebDatePickerState extends State<_WebDatePicker> {
                 const Spacer(),
 
                 /// CANCEL
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(
-                    localizations.cancelButtonLabel,
-                    style: TextStyle(color: widget.cancelButtonColor ?? theme.colorScheme.primary),
+                if (widget.showCancelButton)
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(
+                      localizations.cancelButtonLabel,
+                      style: TextStyle(color: widget.cancelButtonColor ?? theme.colorScheme.primary),
+                    ),
                   ),
-                ),
 
                 /// OK
-                if (_curViewMode == widget.initViewMode) ...[
+                if (widget.showOkButton && _curViewMode == widget.initViewMode) ...[
                   const SizedBox(width: 4.0),
                   TextButton(
                     onPressed: () => Navigator.of(context).pop(DateTimeRange(start: _selectedStartDate, end: _selectedEndDate)),


### PR DESCRIPTION
#### Summary
This PR introduces two new optional boolean parameters, `showCancelButton` and `showOkButton`, to the `showWebDatePicker` function. These parameters allow developers to conditionally hide the Cancel and OK buttons in the date picker dialog, providing greater flexibility for custom UI integrations.

#### Changes Made
- **Function Signature Update**: Added `showCancelButton = true` and `showOkButton = true` to the `showWebDatePicker` function parameters.
- **Widget Constructor**: Updated the `_WebDatePicker` widget constructor to accept and pass these new parameters.
- **Class Fields**: Added corresponding final fields in the `_WebDatePicker` class to store the parameter values.
- **UI Rendering**: Modified the actions row in the `build` method to conditionally render the Cancel and OK buttons based on the new flags:
  - Cancel button is shown only if `widget.showCancelButton` is `true`.
  - OK button is shown only if `widget.showOkButton` is `true` and the current view mode matches the initial view mode.

#### Motivation
The date picker widget is designed to be versatile, but in some use cases, the default action buttons (Cancel and OK) may not be needed. For example:
- When the picker is embedded in a form with external confirmation logic.
- In scenarios where date selection triggers immediate actions without requiring explicit user confirmation.
- To create a more streamlined UI for specific application workflows.

By allowing these buttons to be hidden, developers can customize the picker's appearance and behavior to better fit their application's needs without modifying the core widget code.

#### Backward Compatibility
- Both new parameters default to `true`, ensuring existing code continues to work without changes.
- No breaking changes to the API or existing functionality.

#### Example Usage
```dart
// Hide both buttons
await showWebDatePicker(
  context: context,
  initialDate: DateTime.now(),
  showCancelButton: false,
  showOkButton: false,
);

// Hide only the OK button
await showWebDatePicker(
  context: context,
  initialDate: DateTime.now(),
  showOkButton: false,
);
```

#### Testing
- Verified that the widget compiles without errors.
- Confirmed that buttons are hidden when parameters are set to `false`.
- Ensured default behavior remains unchanged when parameters are omitted.