### PR TITLE
feat: add showDisabledCursor parameter to control disabled date cursor style

### DIFF
--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -34,6 +34,7 @@ Future<DateTimeRange?> showWebDatePicker({
   bool showOkButton = true,
   bool showCancelButton = true,
   bool autoCloseOnDateSelect = false,
+  bool showDisabledCursor = false,
   void Function()? onReset,
 }) {
   if (asDialog) {
@@ -66,6 +67,7 @@ Future<DateTimeRange?> showWebDatePicker({
               autoCloseOnDateSelect: autoCloseOnDateSelect,
               showOkButton: showOkButton,
               showCancelButton: showCancelButton,
+              showDisabledCursor: showDisabledCursor,
               onReset: onReset,
             ),
           ),
@@ -95,6 +97,7 @@ Future<DateTimeRange?> showWebDatePicker({
         autoCloseOnDateSelect: autoCloseOnDateSelect,
         showOkButton: showOkButton,
         showCancelButton: showCancelButton,
+        showDisabledCursor: showDisabledCursor,
         onReset: onReset,
       ),
       asDropDown: true,
@@ -125,6 +128,7 @@ class _WebDatePicker extends StatefulWidget {
     this.showOkButton = true,
     this.showCancelButton = true,
     this.autoCloseOnDateSelect = false,
+    this.showDisabledCursor = false,
     this.onReset,
   });
 
@@ -147,6 +151,7 @@ class _WebDatePicker extends StatefulWidget {
   final bool showOkButton;
   final bool showCancelButton;
   final bool autoCloseOnDateSelect;
+  final bool showDisabledCursor;
   final void Function()? onReset;
 
   @override
@@ -296,6 +301,11 @@ class _WebDatePickerState extends State<_WebDatePicker> {
             customBorder: const CircleBorder(),
             child: child,
           );
+        } else if (widget.showDisabledCursor) {
+          child = MouseRegion(
+            cursor: SystemMouseCursors.forbidden,
+            child: child,
+          );
         }
         if (widget.enableRangeSelection) {
           final dfBorderSide = BorderSide(color: color, width: 1.0, style: BorderStyle.solid);
@@ -377,6 +387,11 @@ class _WebDatePickerState extends State<_WebDatePicker> {
           borderRadius: borderRadius,
           child: child,
         );
+      } else {
+        child = MouseRegion(
+          cursor: SystemMouseCursors.forbidden,
+          child: child,
+        );
       }
       children.add(
         Padding(
@@ -426,6 +441,11 @@ class _WebDatePickerState extends State<_WebDatePicker> {
             }
           },
           borderRadius: borderRadius,
+          child: child,
+        );
+      } else if (widget.showDisabledCursor) {
+        child = MouseRegion(
+          cursor: SystemMouseCursors.forbidden,
           child: child,
         );
       }
@@ -480,6 +500,11 @@ class _WebDatePickerState extends State<_WebDatePicker> {
             }
           },
           borderRadius: borderRadius,
+          child: child,
+        );
+      } else if (widget.showDisabledCursor) {
+        child = MouseRegion(
+          cursor: SystemMouseCursors.forbidden,
           child: child,
         );
       }


### PR DESCRIPTION
## Add showDisabledCursor parameter to control disabled date cursor

### Changes
- Added `showDisabledCursor` boolean parameter to `showWebDatePicker` function (default: `false`)
- When enabled, displays a forbidden cursor (`SystemMouseCursors.forbidden`) when hovering over disabled dates
- Applied consistently across all view modes (day, month, year, century)

### Behavior
- When `showDisabledCursor: true` - disabled dates show a forbidden cursor on hover
- When `showDisabledCursor: false` (default) - disabled dates maintain the standard cursor (backward compatible)