### PR TITLE
fix: Support for Dark Mode by removing hardcoded colors

### DIFF
--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -194,7 +194,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
   }
 
   List<Widget> _buildDaysOfMonthCells(ThemeData theme) {
-    final textStyle = theme.textTheme.bodySmall?.copyWith(color: Colors.black);
+    final textStyle = theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface);
     final now = DateTime.now();
     final monthDateRange = _viewStartDate.monthDateTimeRange(
       includeTrailingAndLeadingDates: true,
@@ -348,7 +348,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
   }
 
   List<Widget> _buildMonthsOfYearCells(ThemeData theme) {
-    final textStyle = theme.textTheme.bodySmall?.copyWith(color: Colors.black);
+    final textStyle = theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface);
     final borderRadius = BorderRadius.circular(_childSize!.height / 4 - 32);
     final children = <Widget>[];
     final now = DateTime.now();
@@ -404,7 +404,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
   }
 
   List<Widget> _buildYearsCells(ThemeData theme) {
-    final textStyle = theme.textTheme.bodySmall?.copyWith(color: Colors.black);
+    final textStyle = theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface);
     final borderRadius = BorderRadius.circular(_childSize!.height / 5 - 16);
     final children = <Widget>[];
     final now = DateTime.now();
@@ -460,7 +460,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
   }
 
   List<Widget> _buildYearsOfCenturyCells(ThemeData theme) {
-    final textStyle = theme.textTheme.bodySmall?.copyWith(color: Colors.black);
+    final textStyle = theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface);
     final borderRadius = BorderRadius.circular(_childSize!.height / 5 - 16);
     final children = <Widget>[];
     final now = DateTime.now();
@@ -569,7 +569,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
           alignment: Alignment.center,
           child: Text(
             localizations.formatMonthYear(_viewStartDate).capitalize(),
-            style: theme.textTheme.bodyLarge?.copyWith(color: Colors.black, fontWeight: FontWeight.bold),
+            style: theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface, fontWeight: FontWeight.bold),
           ),
         );
         final monthDateRange = _viewStartDate.monthDateTimeRange(
@@ -586,7 +586,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
           alignment: Alignment.center,
           child: Text(
             localizations.formatYear(_viewStartDate),
-            style: theme.textTheme.bodyLarge?.copyWith(color: Colors.black, fontWeight: FontWeight.bold),
+            style: theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface, fontWeight: FontWeight.bold),
           ),
         );
         isFirst = _viewStartDate.year <= widget.firstDate.year;
@@ -602,7 +602,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
           alignment: Alignment.center,
           child: Text(
             "$year - ${year + 19}",
-            style: theme.textTheme.bodyLarge?.copyWith(color: Colors.black, fontWeight: FontWeight.bold),
+            style: theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface, fontWeight: FontWeight.bold),
           ),
         );
         nextView = widget.lastDate.year - widget.firstDate.year > 20;
@@ -616,7 +616,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
           alignment: Alignment.center,
           child: Text(
             "$year - ${year + 199}",
-            style: theme.textTheme.bodyLarge?.copyWith(color: Colors.black, fontWeight: FontWeight.bold),
+            style: theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface, fontWeight: FontWeight.bold),
           ),
         );
         nextView = false;

--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -761,11 +761,13 @@ class _WebDatePickerState extends State<_WebDatePicker> {
     String? tooltip,
     GestureTapCallback? onTap,
   }) {
+    final theme = Theme.of(context);
+    final iconColor = color ?? theme.colorScheme.onSurface;
     final child = Container(
       height: kActionHeight,
       width: kActionHeight,
       alignment: Alignment.center,
-      child: tooltip != null ? Tooltip(message: tooltip, child: Icon(icon, color: color)) : Icon(icon, color: color),
+      child: tooltip != null ? Tooltip(message: tooltip, child: Icon(icon, color: iconColor)) : Icon(icon, color: iconColor),
     );
     if (onTap != null) {
       return InkWell(


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the date picker's text and navigation icons become completely unreadable when the parent application uses a Dark Theme.

### The Problem
Currently, the package hardcodes `Colors.black` for text styles (e.g., `theme.textTheme.bodySmall?.copyWith(color: Colors.black)`) and relies on default unstyled colors for action icons. When the app switches to Dark Mode and the calendar background adapts to a darker color, the black text and icons blend into the background, making the UI unusable.

### The Solution
* Replaced all hardcoded instances of `Colors.black` with `theme.colorScheme.onSurface`.
* Updated the `_iconWidget` method to fall back to `theme.colorScheme.onSurface` if no specific color is provided.

### Result
The `vph_web_date_picker` now natively respects the Material 3 Theme provided by the parent application. It automatically renders black text/icons in Light Mode and white/light gray text/icons in Dark Mode, ensuring perfect readability in all scenarios. No functional logic has been changed.