### PR TITLE
Fix: Invisible selected date

### DIFF
--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -244,7 +244,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
           margin: EdgeInsets.all(2.0),
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: isEnabled && isSelected ? color : null,
+            color: isSelected ? color : null,
             border: isNow && !isSelected ? Border.all(color: color) : null,
           ),
           child: Text(date.day.toString(), style: cellTextStyle),


### PR DESCRIPTION
Problem: When an initialDate is provided that falls outside the allowed range (e.g., it is disabled), the calendar assigns a white text color (onPrimary) to the selected day, but sets the background color to null because of the isEnabled && isSelected condition in BoxDecoration. This makes the text invisible on light themes.

Solution: Changed the background color logic to color: isSelected ? color : null. The color variable is already properly calculated a few lines above to have a lower opacity (.withAlpha(128)) if the date is disabled. This change allows the disabled-but-selected date to show a greyed-out primary background, making the white text readable and indicating what the current initial value is without allowing the user to select other disabled dates.