### PR TITLE
fix: make "Today" button select current date and respect auto-close

### DIFF
--- a/lib/src/web_date_picker.dart
+++ b/lib/src/web_date_picker.dart
@@ -560,6 +560,44 @@ class _WebDatePickerState extends State<_WebDatePicker> {
     }
   }
 
+  void _onSelectToday() {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    final isEnabled = today.isInDateRange(widget.firstDate, widget.lastDate) && 
+                      !today.isBlockedDate(widget.blockedDates, today);
+
+    if (!isEnabled) {
+      setState(() {
+        _viewStartDate = today;
+        _curViewMode = PickerViewMode.day;
+      });
+      return; 
+    }
+
+    if (widget.enableRangeSelection) {
+      setState(() {
+        _viewStartDate = today;
+        _curViewMode = PickerViewMode.day;
+        _selectedStartDate = today;
+        _selectedEndDate = today;
+        _hoveredStartDate = null;
+        _hoveredEndDate = null;
+      });
+    } else {
+      setState(() {
+        _viewStartDate = today;
+        _curViewMode = PickerViewMode.day;
+        _selectedStartDate = today;
+        _selectedEndDate = today;
+      });
+
+      if (widget.autoCloseOnDateSelect) {
+        Navigator.of(context).pop(DateTimeRange(start: _selectedStartDate, end: _selectedEndDate));
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -726,7 +764,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
                 if (widget.showTodayButton)
                   if (widget.todayButtonText != null)
                     TextButton(
-                      onPressed: () => _onStartDateChanged(),
+                      onPressed: _onSelectToday,
                       child: Text(
                         widget.todayButtonText!,
                         style: TextStyle(
@@ -738,7 +776,7 @@ class _WebDatePickerState extends State<_WebDatePicker> {
                     _iconWidget(
                       Icons.today,
                       tooltip: localizations.currentDateLabel,
-                      onTap: _onStartDateChanged,
+                      onTap: _onSelectToday,
                     ),
 
                 const Spacer(),


### PR DESCRIPTION
### What does this PR do?
Currently, the "Today" button only navigates the view to the current month but does not select the date or close the dialog (when `autoCloseOnDateSelect` is true). This PR updates the button's behavior to actually select today's date.

### Changes made:
1. Created a new `_onSelectToday` method dedicated to the "Today" button.
2. The method checks if today's date is within the allowed range (`firstDate`, `lastDate`) and not inside `blockedDates`. 
   - If it's disabled/blocked: It only scrolls the view to the current month (fallback to old behavior).
   - If it's enabled: It selects the current date, updates the state, and successfully pops the navigator if `autoCloseOnDateSelect` is `true`.
3. Replaced `_onStartDateChanged()` with `_onSelectToday()` in the Today button `onPressed`/`onTap` handlers.

This greatly improves the UX, as users naturally expect the "Today" button to pick the date, not just scroll to it.